### PR TITLE
FIX: buffer overflow when posting

### DIFF
--- a/include/models/post.h
+++ b/include/models/post.h
@@ -5,6 +5,8 @@
 
 #include "list.h"
 
+#define MAX_BODY_LEN 65536
+
 typedef struct Post {
     int id;
     int createdAt;

--- a/src/main.c
+++ b/src/main.c
@@ -274,7 +274,7 @@ static Response *profile(Request *req)
     Connection *connection = connectionGetByAccountIds(DB,
                                                        req->account->id,
                                                        account->id);
-    char connectStr[255];
+    char connectStr[512];
 
     if (connection) {
         sprintf(connectStr, "You and %s are connected!", account->name);
@@ -287,7 +287,8 @@ static Response *profile(Request *req)
     }
 
     char *res = NULL;
-    char sbuff[1024];
+    char sbuff[128];
+    char *bbuff = NULL;
     time_t t;
     bool liked;
 
@@ -302,8 +303,9 @@ static Response *profile(Request *req)
         post = (Post *)postCell->value;
         liked = likeLiked(DB, req->account->id, post->id);
 
-        sprintf(sbuff, "<li>%s<hr/>", post->body);
-        bsLCat(&res, sbuff);
+        bbuff = bsNewLen("", strlen(post->body) + 256);
+        sprintf(bbuff, "<li>%s<hr/>", post->body);
+        bsLCat(&res, bbuff);
 
         if (liked) {
             bsLCat(&res, "Liked - ");
@@ -313,10 +315,11 @@ static Response *profile(Request *req)
         }
 
         t = post->createdAt;
-        strftime(sbuff, 1024, "%c GMT", gmtime(&t));
+        strftime(sbuff, 128, "%c GMT", gmtime(&t));
         bsLCat(&res, sbuff);
         bsLCat(&res, "</li>");
 
+        bsDel(bbuff);
         postDel(post);
         postPCell = postCell;
         postCell  = postCell->next;


### PR DESCRIPTION
I use `bsNewLen` to malloc a memory which the size is bigger than `strlen(post->body)` and `"<li><span class=\"act\">%s posted:</span>..."` strings.
also, I add a global variable `MAX_BODY_LEN` to make sure users will not post too many words.
