### PR TITLE
Fix compatible issue for Mac OS X

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,14 @@
-CFLAGS = -O2 -g -std=c99 -Wall -D_POSIX_SOURCE -I include
+CFLAGS = -O2 -g -std=c99 -Wall -I include
 LDFLAGS = -lsqlite3
+
+UNAME_S = $(shell uname -s)
+ifeq ($(UNAME_S),Linux)
+	CFLAGS += -D_POSIX_C_SOURCE
+endif
+ifeq ($(UNAME_S),Darwin)
+	CFLAGS += -D_POSIX_C_SOURCE=199506L
+endif
+
 
 OUT = bin
 EXEC = $(OUT)/facebooc


### PR DESCRIPTION
`strtok_r` is provided by POSIX.1c-1995 and POSIX.1i-1995, however, with
the POSIX_C_SOURCE=1 on Mac OS X is corresponding to the version of
1988 which is too old (Defined in sys/cdefs.h).
