### PR TITLE
Slightly optimize serverServe

### DIFF
--- a/src/request.c
+++ b/src/request.c
@@ -9,29 +9,28 @@ static inline char *urldecode(char *segment)
 {
     char *cc   = segment;
     char *bs   = bsNew("");
-    char cb[3] = "\0\0\0";
-    char c[2]  = "\0\0";
+    char escCode[3] = "\0\0\0";
+    char escChar[2] = "\0\0";
 
     while (*cc != '\0') {
-        if (*cc == '+') *cc = ' ';
-        if (*cc == '%') {
-            *cc = '\0';
+        switch (*cc) {
+            case '+': 
+                *cc = ' ';
+                break;
+            case '%': 
+                *cc++ = '\0';
+                bsLCat(&bs, segment);
+                escCode[0] = *cc++;
+                escCode[1] = *cc++;
+                escChar[0] = (char) strtol(escCode, NULL, 16);
 
-            bsLCat(&bs, segment);
+                segment = cc;
 
-            cb[0] = *(cc + 1);
-            cb[1] = *(cc + 2);
-            c[0]  = (char) strtol(cb, NULL, 16);
-
-            cc     += 2;
-            segment = cc + 1;
-
-            bsLCat(&bs, c);
+                bsLCat(&bs, escChar);
+                break;
         }
-
         cc++;
     }
-
     bsLCat(&bs, segment);
 
     return bs;


### PR DESCRIPTION
Change control flow of `serverServe` 

In previous, we always check all fd in for-loop FD_SETSIZE times
But actually we do not use such many fd, so we waste a lot of time in checking fd.
Fd  is always  bigger than previous, so `sock` should be smallest after `serverServe` 

After optimize, measure by perf record -F 25000
Clock percentage of `serverServe` reduces from 3% to 0.6%
But didn't obviously reduce execution time.  (GET 1000 times improve about 1% to equal)
