### PR TITLE
Replace unsigned int with uint16_t to express the dynamically allocat…

### DIFF
--- a/include/server.h
+++ b/include/server.h
@@ -14,7 +14,7 @@ typedef struct Server {
 typedef Response *(*Handler)(Request *);
 typedef Response *(**HandlerP)(Request *);
 
-Server *serverNew(unsigned int);
+Server *serverNew(uint16_t);
 void    serverDel(Server *);
 void    serverAddHandler(Server *, Handler);
 void    serverAddStaticHandler(Server *);

--- a/src/main.c
+++ b/src/main.c
@@ -111,7 +111,7 @@ int main(int argc, char *argv[])
 
     initDB();
 
-    unsigned int server_port = 8080;
+    uint16_t server_port = 8080;
     if (argc > 1) {
         if (sscanf(argv[1], "%u", &server_port) == 0 || server_port > 65535) {
             fprintf(stderr, "error: invalid command line argument, using default port 8080.\n");

--- a/src/server.c
+++ b/src/server.c
@@ -60,7 +60,7 @@ char *METHODS[8] = {
     "OPTIONS", "GET", "HEAD", "POST", "PUT", "DELETE", "TRACE", "CONNECT"
 };
 
-Server *serverNew(unsigned int port)
+Server *serverNew(uint16_t port)
 {
     Server *server = malloc(sizeof(Server));
     server->port = port;


### PR DESCRIPTION
Use **unsigned int** to express a dynamic allocate port (1024~65535) will lead to very confusing problems in the future with overflows and the like when porting to other platforms, better is to use **uint16_t**.
