### PR TITLE
Prevent escape html tag when create a new posts

### DIFF
--- a/src/models/post.c
+++ b/src/models/post.c
@@ -30,11 +30,9 @@ Post *postCreate(sqlite3 *DB, int authorId, char *body)
 
     if (rc != SQLITE_OK) return NULL;
 
-    char *escapedBody = bsEscape(body);
-
     if (sqlite3_bind_int(statement, 1, t) != SQLITE_OK) goto fail;
     if (sqlite3_bind_int(statement, 2, authorId) != SQLITE_OK) goto fail;
-    if (sqlite3_bind_text(statement, 3, escapedBody, -1, NULL) != SQLITE_OK)
+    if (sqlite3_bind_text(statement, 3, body, -1, NULL) != SQLITE_OK)
         goto fail;
 
     if (sqlite3_step(statement) == SQLITE_DONE)
@@ -42,7 +40,6 @@ Post *postCreate(sqlite3 *DB, int authorId, char *body)
                        t, authorId, body);
 
 fail:
-    bsDel(escapedBody);
     sqlite3_finalize(statement);
     return post;
 }


### PR DESCRIPTION
We do not need escape html tag when create a new posts because that will break html syntax in the post field (or in the WYSIWYG editor in the future).
