### PR TITLE
Replace newline character to HTML line breaks in posts

### DIFF
--- a/src/bs.c
+++ b/src/bs.c
@@ -150,6 +150,29 @@ void bsSetLen(char *bs, uint32_t len)
     *(bs + len) = '\0';
 }
 
+char *bsNl2Br(char* bs)
+{
+    char *copy = bsNew(bs);
+    char *res  = bsNew("");
+
+    char *c = copy;
+    char *p = copy;
+
+    while (*c != '\0') {
+        if (*c == '\n') {
+            *c = '\0';
+            bsLCat(&res, p);
+            bsLCat(&res, "<br>");
+            p = c + 1;
+        }
+        ++c;
+    }
+
+    bsLCat(&res, p);
+    bsDel(copy);
+    return res;
+}
+
 uint32_t bsGetLen(char *bs)
 {
     return bs ?

--- a/src/models/post.c
+++ b/src/models/post.c
@@ -30,7 +30,7 @@ Post *postCreate(sqlite3 *DB, int authorId, char *body)
 
     if (rc != SQLITE_OK) return NULL;
 
-    char *escapedBody = bsEscape(body);
+    char *escapedBody = bsNl2Br(bsEscape(body));
 
     if (sqlite3_bind_int(statement, 1, t) != SQLITE_OK) goto fail;
     if (sqlite3_bind_int(statement, 2, authorId) != SQLITE_OK) goto fail;


### PR DESCRIPTION
Let users can write multiple lines in the post.

Add the function that replaces each newline character 
to HTML line breaks when post creates.
![2016-06-14 9 16 49](https://cloud.githubusercontent.com/assets/4388697/16044113/a8be9f78-3275-11e6-8ff8-4b285cb24485.png)
