### PR TITLE
Replace newline char to HTML line breaks in posts

### DIFF
--- a/src/bs.c
+++ b/src/bs.c
@@ -150,6 +150,29 @@ void bsSetLen(char *bs, uint32_t len)
     *(bs + len) = '\0';
 }
 
+char *bsNewline2BR(char* bs)
+{
+    char *copy = bsNew(bs);
+    char *res  = bsNew("");
+
+    char *c = copy;
+    char *p = copy;
+
+    while (*c != '\0') {
+        if (*c == '\n') {
+            *c = '\0';
+            bsLCat(&res, p);
+            bsLCat(&res, "<br>");
+            p = c + 1;
+        }
+        ++c;
+    }
+
+    bsLCat(&res, p);
+    bsDel(copy);
+    return res;
+}
+
 uint32_t bsGetLen(char *bs)
 {
     return bs ?

--- a/src/models/post.c
+++ b/src/models/post.c
@@ -69,7 +69,7 @@ Post *postGetById(sqlite3 *DB, int id)
     post = postNew(sqlite3_column_int(statement, 0),
                    sqlite3_column_int(statement, 1),
                    sqlite3_column_int(statement, 2),
-                   (char *)sqlite3_column_text(statement, 3));
+                   bsNewline2BR((char *)sqlite3_column_text(statement, 3)));
 
 fail:
     sqlite3_finalize(statement);
@@ -104,7 +104,7 @@ ListCell *postGetLatest(sqlite3 *DB, int accountId, int page)
         post = postNew(sqlite3_column_int(statement, 0),
                        sqlite3_column_int(statement, 1),
                        sqlite3_column_int(statement, 2),
-                       (char *)sqlite3_column_text(statement, 3));
+                       bsNewline2BR((char *)sqlite3_column_text(statement, 3)));
         posts = listCons(post, sizeof(Post), posts);
     }
 
@@ -147,7 +147,7 @@ ListCell *postGetLatestGraph(sqlite3 *DB, int accountId, int page)
         post = postNew(sqlite3_column_int(statement, 0),
                        sqlite3_column_int(statement, 1),
                        sqlite3_column_int(statement, 2),
-                       (char *)sqlite3_column_text(statement, 3));
+                       bsNewline2BR((char *)sqlite3_column_text(statement, 3)));
         posts = listCons(post, sizeof(Post), posts);
     }
 


### PR DESCRIPTION
When a user sends multiple lines post, server will save newline char
to database. When it views on web it should be translated to HTML
line breaks.

It results in user see multiple lines posts to be one line on browser.

Add the function that replaces each newline character to HTML line
breaks let users can write multiple lines in a post.

![2016-06-14 9 16 49](https://cloud.githubusercontent.com/assets/4388697/16044113/a8be9f78-3275-11e6-8ff8-4b285cb24485.png)
