### PR TITLE
Eliminate warnings caused by the result of fread

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -128,7 +128,7 @@ static Response *staticHandler(Request *req)
     Response *response = responseNew();
 
     buff = malloc(sizeof(char) * len);
-    fread(buff, sizeof(char), len, file);
+    (void) !fread(buff, sizeof(char), len, file);
     responseSetBody(response, bsNewLen(buff, len));
     fclose(file);
     free(buff);

--- a/src/server.c
+++ b/src/server.c
@@ -117,7 +117,7 @@ static Response *staticHandler(Request *req)
     // GET LENGTH
     char *buff;
     char lens[25];
-    size_t len;
+    size_t len, readLen;
 
     fseek(file, 0, SEEK_END);
     len = ftell(file);
@@ -128,7 +128,13 @@ static Response *staticHandler(Request *req)
     Response *response = responseNew();
 
     buff = malloc(sizeof(char) * len);
-    (void) !fread(buff, sizeof(char), len, file);
+    readLen = fread(buff, sizeof(char), len, file);
+    if (readLen != len) {
+        fclose(file);
+        free(buff);
+        responseDel(response);
+        return NULL;
+    }
     responseSetBody(response, bsNewLen(buff, len));
     fclose(file);
     free(buff);

--- a/src/template.c
+++ b/src/template.c
@@ -50,7 +50,7 @@ char *templateRender(Template *template)
     rewind(file);
 
     buff = malloc(sizeof(char) * (len + 2));
-    fread(buff + 1, sizeof(char), len, file);
+    (void) !fread(buff + 1, sizeof(char), len, file);
     fclose(file);
 
     buff[0] = ' ';

--- a/src/template.c
+++ b/src/template.c
@@ -38,7 +38,7 @@ char *templateRender(Template *template)
     char *pos, *buff, *incBs, *val;
     char *segment;
     bool rep = false;
-    size_t len;
+    size_t len, readLen;
 
     if (!file) {
         fprintf(stderr, "error: template '%s' not found\n", template->filename);
@@ -50,7 +50,14 @@ char *templateRender(Template *template)
     rewind(file);
 
     buff = malloc(sizeof(char) * (len + 2));
-    (void) !fread(buff + 1, sizeof(char), len, file);
+    readLen = fread(buff + 1, sizeof(char), len, file);
+    if (readLen != len) {
+        if (feof(file))
+            fprintf(stderr, "error: unexpected end of file in template '%s'\n", template->filename);
+        else
+            fprintf(stderr, "error: failed to read template '%s'\n", template->filename);
+        exit(1);
+    }
     fclose(file);
 
     buff[0] = ' ';


### PR DESCRIPTION
In gcc 9.4.0, the `fread()` function marked with the `__wur` macro generates an `unused-result` warning when the result is not used, and due to the `-Werror` flag in Makefile, it became a compilation error in facebooc (at least on my computer). I added an error handling mechanism that would help when there are errors reading the file.